### PR TITLE
Fix php old

### DIFF
--- a/src/voku/helper/Session2DB.php
+++ b/src/voku/helper/Session2DB.php
@@ -406,8 +406,7 @@ class Session2DB implements \SessionHandlerInterface
       WHERE lock_hash = '" . $this->db->escape($look_name) . "'
       LIMIT 1
     ";
-    $db_result = $this->db->query($query_lock);
-    $old_lock_timeout = $db_result->fetchColumn('lock_time');
+    $old_lock_timeout = $this->db->fetchColumn($query_lock, 'lock_time');
 
     if (!$old_lock_timeout) {
       $query_lock = '

--- a/src/voku/helper/Session2DB.php
+++ b/src/voku/helper/Session2DB.php
@@ -33,7 +33,7 @@ namespace voku\helper;
  * @license http://www.gnu.org/licenses/lgpl-3.0.txt GNU LESSER GENERAL PUBLIC LICENSE
  * @package voku\helper
  */
-class Session2DB /* implements \SessionHandlerInterface // (PHP 5 >= 5.4.0)  */
+class Session2DB implements \SessionHandlerInterface
 {
   /**
    * the name for the session variable that will be created upon script execution


### PR DESCRIPTION
This fixes two issues i found testing version 2.1.0.

1. Session2DB must implement SessionHandlerInterface to work as session implementation
2. The use of own implementations for the db success were broken.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/session2db/10)
<!-- Reviewable:end -->
